### PR TITLE
feat(web,api): Auth Header Login Entry + Profile Page

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -13,6 +13,7 @@ import { LangfuseModule } from './langfuse/langfuse.module';
 import { LyricsModule } from './lyrics/lyrics.module';
 import { AuthModule } from './auth/auth.module';
 import { EmailModule } from './email/email.module';
+import { UsersModule } from './users/users.module';
 
 @Module({
   imports: [
@@ -48,6 +49,7 @@ import { EmailModule } from './email/email.module';
     LyricsModule,
     AuthModule,
     EmailModule,
+    UsersModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/apps/api/src/users/dto/update-user.dto.ts
+++ b/apps/api/src/users/dto/update-user.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateUserDto {
+  @ApiPropertyOptional({ description: 'User nickname (max 20 chars)' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  nickname?: string;
+
+  @ApiPropertyOptional({ description: 'User bio (max 200 chars)' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  bio?: string;
+}
+
+export class UserProfileDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  email: string;
+
+  @ApiProperty({ required: false })
+  nickname?: string;
+
+  @ApiProperty({ required: false })
+  avatar?: string;
+
+  @ApiProperty({ required: false })
+  bio?: string;
+
+  @ApiProperty()
+  emailVerified: boolean;
+}

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,0 +1,46 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Patch,
+  Req,
+  UnauthorizedException,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { UsersService } from './users.service';
+import { JwtAuthGuard, AuthenticatedRequest } from '../auth/guards/jwt-auth.guard';
+import { UpdateUserDto, UserProfileDto } from './dto/update-user.dto';
+
+@ApiTags('users')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get('me')
+  @ApiOperation({ summary: 'Get current user profile' })
+  @ApiResponse({ status: 200, type: UserProfileDto })
+  async getMe(@Req() req: AuthenticatedRequest): Promise<UserProfileDto> {
+    const userId = req.user?.id;
+    if (!userId) {
+      throw new UnauthorizedException('User not found');
+    }
+    return this.usersService.getProfile(userId);
+  }
+
+  @Patch('me')
+  @ApiOperation({ summary: 'Update current user profile' })
+  @ApiResponse({ status: 200, type: UserProfileDto })
+  async updateMe(
+    @Req() req: AuthenticatedRequest,
+    @Body() dto: UpdateUserDto,
+  ): Promise<UserProfileDto> {
+    const userId = req.user?.id;
+    if (!userId) {
+      throw new UnauthorizedException('User not found');
+    }
+    return this.usersService.updateProfile(userId, dto);
+  }
+}

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [UsersController],
+  providers: [UsersService],
+})
+export class UsersModule {}

--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -1,0 +1,113 @@
+import { NotFoundException } from '@nestjs/common';
+import { User } from '@prisma/client';
+import { UsersService } from './users.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+type MockedPrismaService = PrismaService & {
+  user: {
+    findUnique: jest.Mock;
+    update: jest.Mock;
+  };
+};
+
+describe('UsersService', () => {
+  let service: UsersService;
+  let prisma: MockedPrismaService;
+
+  const baseUser: User = {
+    id: 'user-1',
+    email: 'test@example.com',
+    nickname: null,
+    avatar: null,
+    bio: null,
+    emailVerified: false,
+    tokenVersion: 0,
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+  };
+
+  const buildUser = (overrides: Partial<User> = {}): User => ({
+    ...baseUser,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    prisma = {
+      user: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+    } as unknown as MockedPrismaService;
+
+    service = new UsersService(prisma);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  it('getProfile returns mapped user data', async () => {
+    const user = buildUser({ nickname: 'Tester', bio: 'Hello' });
+    prisma.user.findUnique.mockResolvedValue(user);
+
+    const result = await service.getProfile('user-1');
+
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({ where: { id: 'user-1' } });
+    expect(result).toEqual({
+      id: 'user-1',
+      email: 'test@example.com',
+      nickname: 'Tester',
+      avatar: undefined,
+      bio: 'Hello',
+      emailVerified: false,
+    });
+  });
+
+  it('getProfile throws when user not found', async () => {
+    prisma.user.findUnique.mockResolvedValue(null);
+
+    await expect(service.getProfile('missing')).rejects.toThrow(NotFoundException);
+  });
+
+  it('updateProfile updates provided fields', async () => {
+    const user = buildUser({ nickname: 'New Nick', bio: 'New Bio' });
+    prisma.user.update.mockResolvedValue(user);
+
+    const result = await service.updateProfile('user-1', {
+      nickname: 'New Nick',
+      bio: 'New Bio',
+    });
+
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: { nickname: 'New Nick', bio: 'New Bio' },
+    });
+    expect(result).toEqual({
+      id: 'user-1',
+      email: 'test@example.com',
+      nickname: 'New Nick',
+      avatar: undefined,
+      bio: 'New Bio',
+      emailVerified: false,
+    });
+  });
+
+  it('updateProfile returns current profile when no fields are provided', async () => {
+    const user = buildUser();
+    prisma.user.findUnique.mockResolvedValue(user);
+
+    const result = await service.updateProfile('user-1', {});
+
+    expect(prisma.user.update).not.toHaveBeenCalled();
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({ where: { id: 'user-1' } });
+    expect(result).toEqual({
+      id: 'user-1',
+      email: 'test@example.com',
+      nickname: undefined,
+      avatar: undefined,
+      bio: undefined,
+      emailVerified: false,
+    });
+  });
+});

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { UpdateUserDto, UserProfileDto } from './dto/update-user.dto';
+import { User } from '@prisma/client';
+
+@Injectable()
+export class UsersService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getProfile(userId: string): Promise<UserProfileDto> {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    return this.toUserProfile(user);
+  }
+
+  async updateProfile(userId: string, dto: UpdateUserDto): Promise<UserProfileDto> {
+    const data: { nickname?: string | null; bio?: string | null } = {};
+
+    if (dto.nickname !== undefined) {
+      data.nickname = dto.nickname;
+    }
+
+    if (dto.bio !== undefined) {
+      data.bio = dto.bio;
+    }
+
+    if (Object.keys(data).length === 0) {
+      return this.getProfile(userId);
+    }
+
+    const user = await this.prisma.user.update({
+      where: { id: userId },
+      data,
+    });
+
+    return this.toUserProfile(user);
+  }
+
+  private toUserProfile(user: User): UserProfileDto {
+    return {
+      id: user.id,
+      email: user.email,
+      nickname: user.nickname ?? undefined,
+      avatar: user.avatar ?? undefined,
+      bio: user.bio ?? undefined,
+      emailVerified: user.emailVerified,
+    };
+  }
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata, Viewport } from 'next'
 import { Inter, Space_Grotesk } from 'next/font/google'
+import { Header } from '@/components/Header'
+import { AuthProvider } from '@/contexts/AuthContext'
 import { ThemeProvider } from '@/contexts/ThemeContext'
 import './globals.css'
 
@@ -63,7 +65,10 @@ export default function RootLayout({
       </head>
       <body className="min-h-screen antialiased">
         <ThemeProvider>
-          {children}
+          <AuthProvider>
+            <Header />
+            {children}
+          </AuthProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import Link from 'next/link'
-import { ThemeToggle } from '@/components/ThemeToggle'
 
 // Animated sound wave bars component
 function SoundWave({ className = '' }: { className?: string }) {
@@ -80,27 +79,6 @@ export default function Home() {
           }}
         />
       </div>
-
-      {/* Header with Theme Toggle */}
-      <header className="relative z-10 flex justify-between items-center p-4 md:p-6">
-        <div className="flex items-center gap-2">
-          <div
-            className="w-10 h-10 rounded-xl flex items-center justify-center"
-            style={{
-              background: 'linear-gradient(135deg, var(--accent-primary) 0%, #9333EA 100%)',
-              boxShadow: 'var(--shadow-glow-primary)',
-            }}
-          >
-            <svg className="w-5 h-5 text-white" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" />
-            </svg>
-          </div>
-          <span className="font-semibold hidden sm:block" style={{ color: 'var(--text-primary)' }}>
-            AI Music Maker
-          </span>
-        </div>
-        <ThemeToggle />
-      </header>
 
       {/* Hero Section */}
       <section className="relative z-10 flex flex-col items-center justify-center px-6 pt-12 pb-20 md:pt-20 md:pb-32">

--- a/apps/web/src/app/profile/layout.tsx
+++ b/apps/web/src/app/profile/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next'
+import type { ReactNode } from 'react'
+
+export const metadata: Metadata = {
+  title: 'Profile',
+  description: 'Manage your profile settings.',
+}
+
+export default function ProfileLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -1,0 +1,360 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/contexts/AuthContext'
+import type { AuthUser, UpdateProfileData } from '@/lib/authApi'
+
+type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
+
+const MAX_NICKNAME = 20
+const MAX_BIO = 200
+
+export default function ProfilePage() {
+  const router = useRouter()
+  const { user, isLoading, isAuthenticated, updateProfile, logout } = useAuth()
+  const [profile, setProfile] = useState({ nickname: '', bio: '' })
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle')
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [hasCheckedAuth, setHasCheckedAuth] = useState(false)
+  const saveStatusRef = useRef<SaveStatus>('idle')
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pendingSaveRef = useRef(false)
+  const dirtyRef = useRef(false)
+  const profileRef = useRef(profile)
+  const userRef = useRef<AuthUser | null>(null)
+
+  useEffect(() => {
+    if (!isLoading && !hasCheckedAuth) {
+      setHasCheckedAuth(true)
+    }
+  }, [isLoading, hasCheckedAuth])
+
+  useEffect(() => {
+    if (user && !dirtyRef.current) {
+      setProfile({ nickname: user.nickname ?? '', bio: user.bio ?? '' })
+    }
+  }, [user?.nickname, user?.bio])
+
+  useEffect(() => {
+    profileRef.current = profile
+  }, [profile])
+
+  useEffect(() => {
+    userRef.current = user
+  }, [user])
+
+  useEffect(() => {
+    if (hasCheckedAuth && !isLoading && !isAuthenticated) {
+      router.replace('/')
+    }
+  }, [hasCheckedAuth, isLoading, isAuthenticated, router])
+
+  useEffect(() => {
+    return () => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const displayName = useMemo(() => {
+    const trimmedNickname = profile.nickname.trim()
+    if (trimmedNickname) {
+      return trimmedNickname
+    }
+    if (user?.nickname) {
+      return user.nickname
+    }
+    if (user?.email) {
+      return user.email.split('@')[0]
+    }
+    return '用户'
+  }, [profile.nickname, user?.nickname, user?.email])
+
+  const avatarLetter = displayName.trim().charAt(0).toUpperCase()
+
+  const resetSaveState = () => {
+    if (saveStatus !== 'idle') {
+      saveStatusRef.current = 'idle'
+      setSaveStatus('idle')
+    }
+    if (saveError) {
+      setSaveError(null)
+    }
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current)
+      saveTimeoutRef.current = null
+    }
+  }
+
+  const handleFieldChange = (field: 'nickname' | 'bio') => (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const value = event.target.value
+    setProfile(prev => {
+      const next = { ...prev, [field]: value }
+      profileRef.current = next
+      return next
+    })
+    dirtyRef.current = true
+    if (saveStatusRef.current === 'saving') {
+      pendingSaveRef.current = true
+    }
+    if (saveStatusRef.current === 'saved' || saveStatusRef.current === 'error' || saveError) {
+      resetSaveState()
+    }
+  }
+
+  const applySaveStatus = () => {
+    saveStatusRef.current = 'saved'
+    setSaveStatus('saved')
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current)
+    }
+    saveTimeoutRef.current = setTimeout(() => {
+      saveStatusRef.current = 'idle'
+      setSaveStatus('idle')
+      saveTimeoutRef.current = null
+    }, 2000)
+  }
+
+  const handleSave = async (force = false) => {
+    const currentUser = userRef.current
+    if (!currentUser) return
+    if (!force && saveStatusRef.current === 'saving') {
+      pendingSaveRef.current = true
+      return
+    }
+
+    const currentProfile = profileRef.current
+    const nextNickname = currentProfile.nickname.trim()
+    const nextBio = currentProfile.bio.trim()
+    const payload: UpdateProfileData = {}
+    const currentNickname = currentUser.nickname ?? ''
+    const currentBio = currentUser.bio ?? ''
+
+    if (nextNickname !== currentNickname) {
+      payload.nickname = nextNickname
+    }
+    if (nextBio !== currentBio) {
+      payload.bio = nextBio
+    }
+
+    if (Object.keys(payload).length === 0) {
+      dirtyRef.current = false
+      pendingSaveRef.current = false
+      return
+    }
+
+    if (nextNickname !== currentProfile.nickname || nextBio !== currentProfile.bio) {
+      const nextProfile = { nickname: nextNickname, bio: nextBio }
+      profileRef.current = nextProfile
+      setProfile(nextProfile)
+    }
+
+    saveStatusRef.current = 'saving'
+    setSaveStatus('saving')
+    setSaveError(null)
+    let didFail = false
+
+    try {
+      await updateProfile(payload)
+      const hasPending = pendingSaveRef.current
+      dirtyRef.current = hasPending
+      userRef.current = { ...currentUser, ...payload }
+      if (!hasPending) {
+        applySaveStatus()
+      }
+    } catch (error) {
+      didFail = true
+      saveStatusRef.current = 'error'
+      setSaveStatus('error')
+      setSaveError(error instanceof Error ? error.message : '保存失败')
+    } finally {
+      if (pendingSaveRef.current && !didFail) {
+        pendingSaveRef.current = false
+        await handleSave(true)
+      } else if (didFail) {
+        pendingSaveRef.current = false
+      }
+    }
+  }
+
+  const handleLogout = async () => {
+    try {
+      await logout()
+    } finally {
+      router.replace('/')
+    }
+  }
+
+  if (!hasCheckedAuth) {
+    return (
+      <main className="min-h-screen" style={{ backgroundColor: 'var(--bg-base)' }}>
+        <div className="max-w-4xl mx-auto p-4 md:p-8">
+          <div className="flex items-center justify-center h-64">
+            <div
+              className="w-10 h-10 rounded-full animate-spin"
+              style={{
+                border: '3px solid var(--bg-elevated)',
+                borderTopColor: 'var(--accent-primary)',
+              }}
+            />
+          </div>
+        </div>
+      </main>
+    )
+  }
+
+  if (!isAuthenticated) {
+    return null
+  }
+
+  return (
+    <main className="min-h-screen" style={{ backgroundColor: 'var(--bg-base)' }}>
+      <div className="max-w-5xl mx-auto px-4 pb-12">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
+          <div>
+            <h1 className="text-2xl md:text-3xl font-bold" style={{ color: 'var(--text-primary)' }}>
+              个人资料
+            </h1>
+            <p className="mt-1 text-sm md:text-base" style={{ color: 'var(--text-muted)' }}>
+              管理你的昵称和个人简介
+            </p>
+          </div>
+          <div className="flex items-center gap-2 text-sm" aria-live="polite">
+            {saveStatus === 'saving' && (
+              <>
+                <span
+                  className="w-4 h-4 rounded-full animate-spin"
+                  style={{
+                    border: '2px solid var(--bg-elevated)',
+                    borderTopColor: 'var(--accent-primary)',
+                  }}
+                />
+                <span style={{ color: 'var(--text-muted)' }}>保存中...</span>
+              </>
+            )}
+            {saveStatus === 'saved' && (
+              <>
+                <svg className="w-4 h-4" style={{ color: 'var(--accent-success)' }} viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+                <span style={{ color: 'var(--accent-success)' }}>已保存</span>
+              </>
+            )}
+            {saveStatus === 'error' && (
+              <>
+                <svg className="w-4 h-4" style={{ color: 'var(--color-error)' }} viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v4m0 4h.01M12 3a9 9 0 100 18 9 9 0 000-18z" />
+                </svg>
+                <span style={{ color: 'var(--color-error)' }}>{saveError || '保存失败'}</span>
+              </>
+            )}
+            {saveStatus === 'idle' && (
+              <span style={{ color: 'var(--text-subtle)' }}>自动保存</span>
+            )}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-6">
+          <div className="card-glass p-6">
+            <div className="flex flex-col items-center text-center">
+              <div
+                className="w-24 h-24 rounded-full flex items-center justify-center text-3xl font-semibold mb-4"
+                style={{
+                  background: 'linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-success) 100%)',
+                  color: 'white',
+                  boxShadow: 'var(--shadow-glow-primary)',
+                }}
+              >
+                {avatarLetter}
+              </div>
+              <h2 className="text-xl font-semibold" style={{ color: 'var(--text-primary)' }}>
+                {displayName}
+              </h2>
+              <p className="text-sm mt-1" style={{ color: 'var(--text-muted)' }}>
+                {user?.email}
+              </p>
+              {user?.emailVerified === false && (
+                <span className="mt-3 tag" style={{ color: 'var(--color-warning)' }}>
+                  邮箱未验证
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div className="card-glass p-6">
+            <div className="space-y-6">
+              <div>
+                <label className="block text-sm font-medium mb-2" style={{ color: 'var(--text-primary)' }}>
+                  昵称
+                </label>
+                <input
+                  className="input"
+                  value={profile.nickname}
+                  onChange={handleFieldChange('nickname')}
+                  onBlur={() => handleSave()}
+                  placeholder="请输入昵称"
+                  maxLength={MAX_NICKNAME}
+                />
+                <div className="mt-2 flex justify-between text-xs" style={{ color: 'var(--text-subtle)' }}>
+                  <span>最多 {MAX_NICKNAME} 个字符</span>
+                  <span>{profile.nickname.length}/{MAX_NICKNAME}</span>
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium mb-2" style={{ color: 'var(--text-primary)' }}>
+                  邮箱
+                </label>
+                <input
+                  className="input"
+                  value={user?.email ?? ''}
+                  readOnly
+                  disabled
+                  style={{
+                    backgroundColor: 'var(--bg-elevated)',
+                    color: 'var(--text-muted)',
+                  }}
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium mb-2" style={{ color: 'var(--text-primary)' }}>
+                  个人简介
+                </label>
+                <textarea
+                  className="input min-h-[140px] resize-none"
+                  value={profile.bio}
+                  onChange={handleFieldChange('bio')}
+                  onBlur={() => handleSave()}
+                  placeholder="写点关于你的音乐灵感"
+                  maxLength={MAX_BIO}
+                />
+                <div className="mt-2 flex justify-between text-xs" style={{ color: 'var(--text-subtle)' }}>
+                  <span>最多 {MAX_BIO} 个字符</span>
+                  <span>{profile.bio.length}/{MAX_BIO}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-10 flex justify-center">
+          <button
+            onClick={handleLogout}
+            className="btn-secondary w-full sm:w-auto"
+            style={{
+              borderColor: 'rgba(239, 68, 68, 0.4)',
+              color: 'var(--color-error)',
+            }}
+          >
+            退出登录
+          </button>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,0 +1,234 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { ThemeToggle } from '@/components/ThemeToggle'
+import { LoginModal } from '@/components/LoginModal'
+import { useAuth } from '@/contexts/AuthContext'
+
+const AVATAR_COLORS = [
+  'bg-indigo-500',
+  'bg-violet-500',
+  'bg-emerald-500',
+  'bg-amber-500',
+  'bg-rose-500',
+  'bg-sky-500',
+  'bg-teal-500',
+]
+
+export function Header() {
+  const { user, isAuthenticated, isLoading, logout } = useAuth()
+  const [isLoginOpen, setIsLoginOpen] = useState(false)
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  const displayName = user?.nickname || user?.email || '用户'
+  const userEmail = user?.email || ''
+  const avatarLetter = displayName.charAt(0).toUpperCase()
+  const avatarColor = useMemo(() => {
+    if (!displayName) {
+      return AVATAR_COLORS[0]
+    }
+    const index = displayName.charCodeAt(0) % AVATAR_COLORS.length
+    return AVATAR_COLORS[index]
+  }, [displayName])
+
+  useEffect(() => {
+    if (!isDropdownOpen) {
+      return
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsDropdownOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [isDropdownOpen])
+
+  useEffect(() => {
+    if (isLoginOpen) {
+      setIsDropdownOpen(false)
+      setIsMobileMenuOpen(false)
+    }
+  }, [isLoginOpen])
+
+  const handleLogout = async () => {
+    try {
+      await logout()
+    } finally {
+      setIsDropdownOpen(false)
+      setIsMobileMenuOpen(false)
+    }
+  }
+
+  const renderAuthDesktop = () => {
+    if (!isAuthenticated) {
+      return (
+        <button
+          type="button"
+          onClick={() => setIsLoginOpen(true)}
+          className="btn-secondary px-4 py-2 text-sm rounded-xl"
+          disabled={isLoading}
+        >
+          登录
+        </button>
+      )
+    }
+
+    return (
+      <div className="relative" ref={dropdownRef}>
+        <button
+          type="button"
+          onClick={() => setIsDropdownOpen((prev) => !prev)}
+          className="flex items-center gap-2 rounded-full p-1 hover:bg-[var(--surface-hover)] transition-colors"
+          aria-haspopup="menu"
+          aria-expanded={isDropdownOpen}
+        >
+          <span
+            className={`w-9 h-9 rounded-full flex items-center justify-center text-white font-semibold ${avatarColor}`}
+          >
+            {avatarLetter}
+          </span>
+          <svg
+            className={`w-4 h-4 text-muted transition-transform ${isDropdownOpen ? 'rotate-180' : ''}`}
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path
+              fillRule="evenodd"
+              d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.25a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+
+        {isDropdownOpen && (
+          <div className="absolute right-0 mt-3 w-48 rounded-xl bg-surface border border-default shadow-soft-lg p-2 animate-fade-in-down">
+            <div className="px-3 py-2 text-xs text-muted">{userEmail}</div>
+            <Link
+              href="/profile"
+              className="flex items-center gap-2 px-3 py-2 text-sm text-secondary rounded-lg hover:bg-surface-elevated hover:text-primary transition-colors"
+              onClick={() => setIsDropdownOpen(false)}
+            >
+              个人资料
+            </Link>
+            <Link
+              href="/library"
+              className="flex items-center gap-2 px-3 py-2 text-sm text-secondary rounded-lg hover:bg-surface-elevated hover:text-primary transition-colors"
+              onClick={() => setIsDropdownOpen(false)}
+            >
+              作品库
+            </Link>
+            <button
+              type="button"
+              onClick={handleLogout}
+              className="w-full text-left px-3 py-2 text-sm text-error-600 rounded-lg hover:bg-error-50 transition-colors"
+            >
+              退出
+            </button>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  const renderMobileMenu = () => {
+    if (!isMobileMenuOpen) {
+      return null
+    }
+
+    return (
+      <div className="md:hidden border-t border-subtle px-4 pb-4 pt-3 space-y-3 bg-base">
+        {!isAuthenticated ? (
+          <button
+            type="button"
+            onClick={() => setIsLoginOpen(true)}
+            className="btn-primary w-full py-3 rounded-xl"
+            disabled={isLoading}
+          >
+            登录
+          </button>
+        ) : (
+          <div className="space-y-2">
+            <div className="flex items-center gap-3 rounded-xl bg-surface-elevated px-3 py-2">
+              <span
+                className={`w-10 h-10 rounded-full flex items-center justify-center text-white font-semibold ${avatarColor}`}
+              >
+                {avatarLetter}
+              </span>
+              <div className="flex flex-col">
+                <span className="text-sm font-medium text-primary">{displayName}</span>
+                <span className="text-xs text-muted">{userEmail}</span>
+              </div>
+            </div>
+            <Link
+              href="/profile"
+              className="block w-full rounded-xl px-3 py-2 text-sm text-secondary hover:bg-surface-elevated hover:text-primary transition-colors"
+              onClick={() => setIsMobileMenuOpen(false)}
+            >
+              个人资料
+            </Link>
+            <Link
+              href="/library"
+              className="block w-full rounded-xl px-3 py-2 text-sm text-secondary hover:bg-surface-elevated hover:text-primary transition-colors"
+              onClick={() => setIsMobileMenuOpen(false)}
+            >
+              作品库
+            </Link>
+            <button
+              type="button"
+              onClick={handleLogout}
+              className="w-full text-left rounded-xl px-3 py-2 text-sm text-error-600 hover:bg-error-50 transition-colors"
+            >
+              退出
+            </button>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <header className="w-full bg-base border-b border-subtle">
+      <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
+        <Link href="/" className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-xl bg-accent-primary text-white flex items-center justify-center shadow-soft-sm">
+            <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" />
+            </svg>
+          </div>
+          <span className="font-semibold text-primary hidden sm:block">AI Music Maker</span>
+        </Link>
+
+        <div className="hidden md:flex items-center gap-3">
+          <ThemeToggle />
+          {renderAuthDesktop()}
+        </div>
+
+        <div className="md:hidden flex items-center gap-2">
+          <ThemeToggle />
+          <button
+            type="button"
+            onClick={() => setIsMobileMenuOpen((prev) => !prev)}
+            className="w-10 h-10 rounded-xl bg-surface-elevated hover:bg-[var(--surface-hover)] transition-colors flex items-center justify-center"
+            aria-label="打开菜单"
+          >
+            <svg className="w-5 h-5 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {renderMobileMenu()}
+
+      <LoginModal isOpen={isLoginOpen} onClose={() => setIsLoginOpen(false)} />
+    </header>
+  )
+}

--- a/apps/web/src/components/LoginModal.tsx
+++ b/apps/web/src/components/LoginModal.tsx
@@ -1,0 +1,269 @@
+'use client'
+
+import { useEffect, useMemo, useState, type FormEvent, type MouseEvent } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import { googleAuthUrl } from '@/lib/authApi'
+
+interface LoginModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+type AuthMode = 'login' | 'register'
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+const formatApiError = (error: unknown, mode: AuthMode) => {
+  if (error instanceof Error) {
+    const message = error.message
+    if (message.includes('401')) {
+      return '邮箱或密码错误'
+    }
+    if (message.includes('409')) {
+      return '该邮箱已被注册'
+    }
+    if (message.includes('400')) {
+      return '请输入有效的邮箱和密码'
+    }
+    if (message.includes('429')) {
+      return '请求过于频繁，请稍后再试'
+    }
+  }
+  return mode === 'login' ? '登录失败，请稍后重试' : '注册失败，请稍后重试'
+}
+
+export function LoginModal({ isOpen, onClose }: LoginModalProps) {
+  const { login, register } = useAuth()
+  const [mode, setMode] = useState<AuthMode>('login')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const title = mode === 'login' ? '登录' : '注册'
+  const ctaLabel = mode === 'login' ? '登录' : '创建账号'
+
+  const isEmailValid = useMemo(() => EMAIL_REGEX.test(email.trim()), [email])
+  const isPasswordValid = useMemo(() => password.trim().length >= 6, [password])
+
+  const resetForm = () => {
+    setMode('login')
+    setEmail('')
+    setPassword('')
+    setError(null)
+    setIsSubmitting(false)
+  }
+
+  useEffect(() => {
+    if (!isOpen) {
+      resetForm()
+      return
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose()
+      }
+    }
+
+    const originalOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.body.style.overflow = originalOverflow
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isOpen, onClose])
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+
+    if (!email.trim()) {
+      setError('请输入邮箱')
+      return
+    }
+    if (!isEmailValid) {
+      setError('邮箱格式不正确')
+      return
+    }
+    if (!password.trim()) {
+      setError('请输入密码')
+      return
+    }
+    if (!isPasswordValid) {
+      setError('密码至少 6 位')
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      if (mode === 'login') {
+        await login(email.trim(), password)
+      } else {
+        await register(email.trim(), password)
+      }
+      onClose()
+    } catch (err) {
+      setError(formatApiError(err, mode))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose()
+    }
+  }
+
+  const handleGoogleLogin = () => {
+    if (typeof window !== 'undefined') {
+      window.location.href = googleAuthUrl()
+    }
+  }
+
+  if (!isOpen) {
+    return null
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={handleBackdropClick}
+        aria-hidden="true"
+      />
+      <div
+        className="relative w-full h-full sm:h-auto sm:max-w-md bg-surface border border-default shadow-soft-lg sm:rounded-2xl px-6 py-8 sm:py-10 animate-fade-in-up overflow-y-auto"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="login-modal-title"
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute top-4 right-4 w-9 h-9 rounded-full flex items-center justify-center text-muted hover:text-primary hover:bg-[var(--surface-hover)] transition-colors"
+          aria-label="关闭登录窗口"
+        >
+          <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+
+        <div className="flex items-center justify-between mb-6">
+          <h2 id="login-modal-title" className="text-xl font-semibold text-primary">
+            {title}
+          </h2>
+          <div className="flex items-center gap-2 bg-surface-elevated rounded-full p-1">
+            <button
+              type="button"
+              onClick={() => {
+                setMode('login')
+                setError(null)
+              }}
+              className={`px-3 py-1.5 text-sm font-medium rounded-full transition-colors ${
+                mode === 'login'
+                  ? 'bg-accent-primary text-white shadow-soft-sm'
+                  : 'text-muted hover:text-primary'
+              }`}
+            >
+              登录
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setMode('register')
+                setError(null)
+              }}
+              className={`px-3 py-1.5 text-sm font-medium rounded-full transition-colors ${
+                mode === 'register'
+                  ? 'bg-accent-primary text-white shadow-soft-sm'
+                  : 'text-muted hover:text-primary'
+              }`}
+            >
+              注册
+            </button>
+          </div>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-secondary" htmlFor="login-email">
+              邮箱
+            </label>
+            <input
+              id="login-email"
+              type="email"
+              value={email}
+              onChange={(event) => {
+                setEmail(event.target.value)
+                if (error) {
+                  setError(null)
+                }
+              }}
+              className={`input ${
+                error && !isEmailValid ? 'border-error-500 focus:border-error-500' : ''
+              }`}
+              placeholder="you@example.com"
+              autoComplete="email"
+              required
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-secondary" htmlFor="login-password">
+              密码
+            </label>
+            <input
+              id="login-password"
+              type="password"
+              value={password}
+              onChange={(event) => {
+                setPassword(event.target.value)
+                if (error) {
+                  setError(null)
+                }
+              }}
+              className={`input ${
+                error && !isPasswordValid ? 'border-error-500 focus:border-error-500' : ''
+              }`}
+              placeholder="至少 6 位"
+              autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
+              required
+            />
+          </div>
+
+          {error && (
+            <div className="rounded-lg border border-error-200 bg-error-50 px-3 py-2 text-sm text-error-600">
+              {error}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="btn-primary w-full text-base py-3 rounded-xl"
+          >
+            {isSubmitting ? '处理中...' : ctaLabel}
+          </button>
+        </form>
+
+        <div className="mt-6">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="flex-1 h-px bg-[var(--border-subtle)]" />
+            <span className="text-xs text-muted">或</span>
+            <div className="flex-1 h-px bg-[var(--border-subtle)]" />
+          </div>
+          <button
+            type="button"
+            onClick={handleGoogleLogin}
+            className="btn-secondary w-full py-3 rounded-xl"
+          >
+            使用 Google 登录
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -1,0 +1,190 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+import {
+  AuthResponse,
+  AuthUser,
+  UpdateProfileData,
+  getMe,
+  login as loginApi,
+  logout as logoutApi,
+  refresh as refreshApi,
+  register as registerApi,
+  updateMe,
+} from '@/lib/authApi'
+
+interface AuthContextType {
+  user: AuthUser | null
+  accessToken: string | null
+  isLoading: boolean
+  isAuthenticated: boolean
+  login: (email: string, password: string) => Promise<void>
+  register: (email: string, password: string) => Promise<void>
+  logout: () => Promise<void>
+  refreshSession: () => Promise<void>
+  updateProfile: (data: UpdateProfileData) => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null)
+  const [accessToken, setAccessToken] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isAuthenticated, setIsAuthenticated] = useState(false)
+
+  const setSession = (response: AuthResponse) => {
+    setUser(response.user)
+    setAccessToken(response.accessToken)
+    setIsAuthenticated(true)
+    localStorage.setItem('accessToken', response.accessToken)
+    localStorage.setItem('refreshToken', response.refreshToken)
+  }
+
+  const clearSession = () => {
+    setUser(null)
+    setAccessToken(null)
+    setIsAuthenticated(false)
+    localStorage.removeItem('accessToken')
+    localStorage.removeItem('refreshToken')
+  }
+
+  useEffect(() => {
+    let isMounted = true
+
+    const initialize = async () => {
+      const storedAccess = localStorage.getItem('accessToken')
+      const storedRefresh = localStorage.getItem('refreshToken')
+
+      if (!storedAccess && !storedRefresh) {
+        setIsLoading(false)
+        return
+      }
+
+      setIsLoading(true)
+
+      try {
+        if (storedRefresh) {
+          const response = await refreshApi(storedRefresh)
+          if (!isMounted) {
+            return
+          }
+          setSession(response)
+          return
+        }
+
+        if (storedAccess) {
+          setAccessToken(storedAccess)
+          const profile = await getMe()
+          if (!isMounted) {
+            return
+          }
+          setUser(profile)
+          setIsAuthenticated(true)
+        }
+      } catch {
+        if (!isMounted) {
+          return
+        }
+        clearSession()
+      } finally {
+        if (isMounted) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    initialize()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  const login = async (email: string, password: string) => {
+    setIsLoading(true)
+    try {
+      const response = await loginApi(email, password)
+      setSession(response)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const register = async (email: string, password: string) => {
+    setIsLoading(true)
+    try {
+      const response = await registerApi(email, password)
+      setSession(response)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const logout = async () => {
+    const refreshToken = localStorage.getItem('refreshToken')
+    setIsLoading(true)
+    try {
+      if (refreshToken) {
+        await logoutApi(refreshToken)
+      }
+    } finally {
+      clearSession()
+      setIsLoading(false)
+    }
+  }
+
+  const refreshSession = async () => {
+    const refreshToken = localStorage.getItem('refreshToken')
+    if (!refreshToken) {
+      clearSession()
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      const response = await refreshApi(refreshToken)
+      setSession(response)
+    } catch {
+      clearSession()
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const updateProfile = async (data: UpdateProfileData) => {
+    setIsLoading(true)
+    try {
+      const profile = await updateMe(data)
+      setUser(profile)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        accessToken,
+        isLoading,
+        isAuthenticated,
+        login,
+        register,
+        logout,
+        refreshSession,
+        updateProfile,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider')
+  }
+  return context
+}

--- a/apps/web/src/lib/authApi.ts
+++ b/apps/web/src/lib/authApi.ts
@@ -1,0 +1,81 @@
+import { apiFetch } from './api'
+
+export interface AuthUser {
+  id: string
+  email: string
+  nickname?: string
+  avatar?: string
+  bio?: string
+  emailVerified: boolean
+}
+
+export interface AuthResponse {
+  accessToken: string
+  refreshToken: string
+  user: AuthUser
+}
+
+export interface UpdateProfileData {
+  nickname?: string
+  bio?: string
+}
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001'
+
+const getAccessToken = () => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+  return localStorage.getItem('accessToken')
+}
+
+const authHeaders = (): Record<string, string> => {
+  const token = getAccessToken()
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+export async function login(email: string, password: string) {
+  return apiFetch<AuthResponse>('/auth/login', {
+    method: 'POST',
+    body: JSON.stringify({ email, password }),
+  })
+}
+
+export async function register(email: string, password: string) {
+  return apiFetch<AuthResponse>('/auth/register', {
+    method: 'POST',
+    body: JSON.stringify({ email, password }),
+  })
+}
+
+export async function logout(refreshToken: string) {
+  return apiFetch<{ success: boolean }>('/auth/logout', {
+    method: 'POST',
+    body: JSON.stringify({ refreshToken }),
+  })
+}
+
+export async function refresh(refreshToken: string) {
+  return apiFetch<AuthResponse>('/auth/refresh', {
+    method: 'POST',
+    body: JSON.stringify({ refreshToken }),
+  })
+}
+
+export async function getMe() {
+  return apiFetch<AuthUser>('/users/me', {
+    headers: authHeaders(),
+  })
+}
+
+export async function updateMe(data: UpdateProfileData) {
+  return apiFetch<AuthUser>('/users/me', {
+    method: 'PATCH',
+    headers: authHeaders(),
+    body: JSON.stringify(data),
+  })
+}
+
+export function googleAuthUrl() {
+  return `${API_BASE_URL}/auth/google`
+}


### PR DESCRIPTION
## Summary
实现全局 Header 登录入口和用户资料页

- Implements #8 (Auth: 实现全局 Header 登录入口)
- Implements #9 (Auth: 实现用户资料页)

## Changes

### Backend (`apps/api`)
- 新增 `UsersModule` with GET/PATCH `/users/me` endpoints
- JWT 保护的用户资料读取/更新
- DTO 验证 (nickname ≤20, bio ≤200)
- 单元测试覆盖

### Frontend (`apps/web`)
- `AuthContext` with localStorage token 持久化
- `authApi` helper functions (login/register/logout/refresh/getMe/updateMe)
- 全局 `Header` 组件 (登录按钮 / 用户头像下拉)
- `LoginModal` (登录/注册 tabs + Google OAuth)
- `/profile` 页面 with blur 即时保存
- 响应式适配 + Light/Dark 主题

## Test Plan
- [x] TypeScript 编译通过
- [x] Frontend 构建成功
- [x] Backend 单元测试通过 (50 tests)
- [ ] 手动测试登录/注册流程
- [ ] 手动测试资料编辑保存
- [ ] 手动测试登出功能

## Screenshots
待手动验证后补充

Closes #8
Closes #9

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user profile management with ability to view and edit nickname and bio.
  * Introduced dedicated profile settings page.
  * Enhanced authentication UI with header navigation, login modal, and user dropdown menu.
  * Added Google OAuth login support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->